### PR TITLE
Improve 32bit build detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 
 option(BUILD_PLUGIN "Build OBS plugin" ON)
 
-if (${CMAKE_C_FLAGS} MATCHES "-m32")
+if (${CMAKE_SIZEOF_VOID_P} EQUAL 4)
     set(LAYER_SUFFIX "_32")
 else()
     set(LAYER_SUFFIX "_64")


### PR DESCRIPTION
One can easily make an 32bit build without having `-m32` in CFLAGS, e.g. in native builds.
Checking `CMAKE_SIZEOF_VOID_P` is probably the most reliable way to differentiate between an 32bit and a 64bit system.