### PR TITLE
Add Flatpak support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,6 @@ pkg_check_modules(XCB xcb IMPORTED_TARGET)
 pkg_check_modules(XCB_XFIXES xcb-xfixes IMPORTED_TARGET)
 pkg_check_modules(WAYLAND_CLIENT wayland-client IMPORTED_TARGET)
 
-if (NOT TARGET libobs)
-    find_package(LibObs REQUIRED)
-endif()
-
 if (VULKAN_FOUND AND NOT TARGET Vulkan::Vulkan)
     add_library(Vulkan::Vulkan UNKNOWN IMPORTED)
     set_target_properties(Vulkan::Vulkan PROPERTIES
@@ -44,6 +40,10 @@ endif()
 set(CMAKE_C_STANDARD 11)
 
 if (BUILD_PLUGIN)
+    if (NOT TARGET libobs)
+        find_package(LibObs REQUIRED)
+    endif()
+
     set(PLUGIN_SOURCES src/vkcapture.c)
     set(PLUGIN_LIBS libobs obs-frontend-api)
     if (HAVE_X11_XCB)

--- a/dist/flatpak/com.obsproject.Studio.Plugin.VkCapture.metainfo.xml
+++ b/dist/flatpak/com.obsproject.Studio.Plugin.VkCapture.metainfo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.obsproject.Studio.Plugin.VkCapture</id>
+  <extends>com.obsproject.Studio</extends>
+  <name>OBS Vulkan/OpenGL Capture</name>
+  <summary>OBS Linux Vulkan/OpenGL game capture</summary>
+  <url type="homepage">https://github.com/nowrep/obs-vkcapture</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0</project_license>
+</component>

--- a/dist/flatpak/com.obsproject.Studio.Plugin.VkCapture.yml
+++ b/dist/flatpak/com.obsproject.Studio.Plugin.VkCapture.yml
@@ -1,0 +1,27 @@
+id: com.obsproject.Studio.Plugin.VkCapture
+branch: stable
+runtime: com.obsproject.Studio
+runtime-version: stable
+sdk: org.kde.Sdk//5.15-21.08
+build-extension: true
+separate-locales: false
+appstream-compose: false
+build-options:
+  prefix: /app/plugins/VkCapture
+modules:
+  - name: VkCapture
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DLIBOBS_INCLUDE_DIR=/app/include/obs
+    post-install:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo ${FLATPAK_ID}.metainfo.xml
+      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak ${FLATPAK_ID}
+    cleanup:
+      - '/bin'
+    sources:
+      - type: git
+        url: https://github.com/nowrep/obs-vkcapture.git
+        tag: v1.1
+      - type: file
+        path: com.obsproject.Studio.Plugin.VkCapture.metainfo.xml


### PR DESCRIPTION
Hello,
since OBS also has a Flatpak (which is going to be officially supported by the next OBS release), I thought it would be cool for this plugin to work with it.
So I decided to create a flatpak manifest which can be used to build the plugin for the flatpak version of OBS. This can be installed from the `dist/flatpak` directory with the following command:
```sh
flatpak-builder --user --install --force-clean build-dir com.obsproject.Studio.Plugin.VkCapture.yml
```

Now unfortunately the obs-vkcapture and obs-glcapture tools still need to be installed without flatpak. I moved the check for the OBS libs in the CMake files into the `if (BUILD_PLUGIN)` check so that these tools can be built without the need for OBS to be installed.

I tested this on a laptop with an Intel integrated GPU with a fresh Manjaro install and it works really well:

![Screenshot_20211223_163819](https://user-images.githubusercontent.com/20151081/147264005-35744c3e-e093-4d66-8df0-88657e9159a4.png)

If you want to publish this to flathub you can take a look at this guide: https://github.com/flathub/flathub/wiki/App-Submission.
According to this, they prefer to have the original dev do this.

