### PR TITLE
fix LD_LIBRARY_PATH in obs-glcapture and refactor script

### DIFF
--- a/src/obs-glcapture.in
+++ b/src/obs-glcapture.in
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-OBS_GLCAPTURE_LIBDIR="@CMAKE_INSTALL_PREFIX@/\$LIB"
-OBS_GLCAPTURE_LIB="libobs_glcapture.so"
-
 if [ "$#" -eq 0 ]; then
     programname=`basename "$0"`
     echo "ERROR: No program supplied"
@@ -11,11 +8,6 @@ if [ "$#" -eq 0 ]; then
     exit 1
 fi
 
-if [ -z "${LD_LIBRARY_PATH}" ]; then
-	LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${OBS_GLCAPTURE_LIBDIR}"
-else
-	LD_LIBRARY_PATH="${OBS_GLCAPTURE_LIBDIR}"
-fi
-
-LD_PRELOAD="${LD_PRELOAD}:${OBS_GLCAPTURE_LIB}"
-exec env LD_PRELOAD="${LD_PRELOAD}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" "$@"
+exec env LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}@CMAKE_INSTALL_PREFIX@/\$LIB" \
+	LD_PRELOAD="${LD_PRELOAD}${LD_PRELOAD:+:}libobs_glcapture.so" \
+	"$@"


### PR DESCRIPTION
This commit fixes a bug that inappropriately assigning value
to LD_LIBRARY_PATH: this does not overwrite the variable with new value.