### PR TITLE
Disable DRM format modifier support by enabling OBS_VKCAPTURE_LINEAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Flatpak:
 
 ## Troubleshooting
 
-**Cannot create EGLImage: Arguments are inconsistent**
+**Cannot create EGLImage: Arguments are inconsistent** \
+**Cannot create EGLImage: EGL cannot access a requested resource (for example a context is bound in another thread).**
 
 If you get this error with Vulkan capture, try starting the game with `OBS_VKCAPTURE_LINEAR=1` environment variable.
 

--- a/src/vklayer.c
+++ b/src/vklayer.c
@@ -605,9 +605,6 @@ static inline bool vk_shtex_init_vulkan_tex(struct vk_data *data,
                     modifier_props[i].drmFormatModifier,
                     modifier_props[i].drmFormatModifierPlaneCount);
 #endif
-            if (vkcapture_linear && modifier_props[i].drmFormatModifier != DRM_FORMAT_MOD_LINEAR) {
-                continue;
-            }
             VkPhysicalDeviceImageDrmFormatModifierInfoEXT mod_info = {};
             mod_info.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT;
             mod_info.drmFormatModifier = modifier_props[i].drmFormatModifier;
@@ -1436,10 +1433,14 @@ static VkResult VKAPI_CALL OBS_CreateDevice(VkPhysicalDevice phy_device,
     GETADDR(GetImageSubresourceLayout);
     GETADDR(GetMemoryFdKHR);
 
-    dfuncs->GetImageDrmFormatModifierPropertiesEXT = (PFN_vkGetImageDrmFormatModifierPropertiesEXT)
-        gdpa(device, "vkGetImageDrmFormatModifierPropertiesEXT");
-    if (!dfuncs->GetImageDrmFormatModifierPropertiesEXT) {
-        hlog("DRM format modifier support not available");
+    if (vkcapture_linear) {
+        dfuncs->GetImageDrmFormatModifierPropertiesEXT = NULL;
+    } else {
+        dfuncs->GetImageDrmFormatModifierPropertiesEXT = (PFN_vkGetImageDrmFormatModifierPropertiesEXT)
+            gdpa(device, "vkGetImageDrmFormatModifierPropertiesEXT");
+        if (!dfuncs->GetImageDrmFormatModifierPropertiesEXT) {
+            hlog("DRM format modifier support not available");
+        }
     }
 
 #undef GETADDR


### PR DESCRIPTION
Enabling OBS_VKCAPTURE_LINEAR completely disables DRM format modifier support now. It forces VkImageCreateInfo.tiling to be VK_IMAGE_TILING_LINEAR.