### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Flatpak:
 
 ## Known Issues
 
-* Requires VK_EXT_external_memory_dma_buf - not available in NVIDIA proprietary driver
+* None
 
 ## Troubleshooting
 


### PR DESCRIPTION
Nvidia released a new drive with the missing extension added. Seems to work now.