### PR TITLE
Fix build with OBS without wayland support

### DIFF
--- a/src/vkcapture.c
+++ b/src/vkcapture.c
@@ -728,7 +728,12 @@ static void *server_thread_run(void *data)
 
 bool obs_module_load(void)
 {
-    if (obs_get_nix_platform() != OBS_NIX_PLATFORM_X11_EGL && obs_get_nix_platform() != OBS_NIX_PLATFORM_WAYLAND) {
+    enum obs_nix_platform_type platform = obs_get_nix_platform();
+#if HAVE_WAYLAND
+    if (platform != OBS_NIX_PLATFORM_X11_EGL && platform != OBS_NIX_PLATFORM_WAYLAND) {
+#else
+    if (platform != OBS_NIX_PLATFORM_X11_EGL) {
+#endif
         blog(LOG_ERROR, "linux-vkcapture cannot run on non-EGL platforms");
         return false;
     }


### PR DESCRIPTION
If OBS is built with ENABLE_WAYLAND=OFF, [obs-nix-platform.h does not contain definition of OBS_NIX_PLATFORM_WAYLAND](https://github.com/obsproject/obs-studio/blob/0a94b3ce16dd6d1ac74479d18730abc001684f37/libobs/obs-nix-platform.h#L29-L31). So an additional guard is needed if the user does not use Wayland and also builds OBS from source.