### PR TITLE
Fix old frames sometimes being captured. (Visual Jitter in OBS capture window)

### DIFF
--- a/src/vklayer.c
+++ b/src/vklayer.c
@@ -958,7 +958,6 @@ static void vk_shtex_destroy_frame_objects(struct vk_data *data,
             &queue_data->frames[frame_idx];
         bool *cmd_buffer_busy = &frame_data->cmd_buffer_busy;
 
-
         VkFence *fence = &frame_data->fence;
         vk_shtex_destroy_fence(data, cmd_buffer_busy, fence);
 

--- a/src/vklayer.h
+++ b/src/vklayer.h
@@ -131,6 +131,8 @@ struct vk_device_funcs {
     DEF_FUNC(GetImageSubresourceLayout);
     DEF_FUNC(GetMemoryFdKHR);
     DEF_FUNC(GetImageDrmFormatModifierPropertiesEXT);
+    DEF_FUNC(CreateSemaphore);
+    DEF_FUNC(DestroySemaphore);
 };
 
 #undef DEF_FUNC


### PR DESCRIPTION
The code for copying the back buffer data wasn't syncrhonized with previous draw commands, which meant every now and then, it'd copy a back buffer that hadn't been altered.

I noticed this when using obs-vkcapture and was getting what appeared as jitter in the output. Recording this output and playing it back I noticed I was getting old frames, (animations looked like they went backwards for a frame).

The general idea for the fix, is to force the QueueSubmit operation for the copy to wait on the semaphores that are passed to `vkQueuePresent`, and then having a semaphore to signal the end of the QueueSubmit and use that instead in `vkQueuePresent`.

This would mean everything that needed to occur for present to be okay with proceeding, has to have occurred for the copy to proceed, and presenting won't proceed until the copy is done.

Now this patch is a quick and dirty fix, and probably needs some work to better fit it in with the surrounding code but I've submitted here to at least show the general idea of what I've done.

I can also confirm, this has fixed my "jitter" in my output.