### PR TITLE
plugin: add additional module metadata

### DIFF
--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,4 +1,5 @@
 GameCapture="Game Capture"
+Description="Linux Vulkan/OpenGL game capture"
 CaptureCursor="Capture Cursor"
 CaptureWindow="Window"
 CaptureAnyWindow="Capture any window"

--- a/src/vkcapture.c
+++ b/src/vkcapture.c
@@ -933,7 +933,7 @@ OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
 
 MODULE_EXPORT const char *obs_module_name(void)
 {
-    return obs_module_text("GameCapture");
+    return PLUGIN_NAME;
 }
 
 MODULE_EXPORT const char *obs_module_description(void)

--- a/src/vkcapture.c
+++ b/src/vkcapture.c
@@ -928,4 +928,15 @@ void obs_module_unload()
 }
 
 OBS_DECLARE_MODULE()
+OBS_MODULE_AUTHOR("David Rosca <nowrep@gmail.com>")
 OBS_MODULE_USE_DEFAULT_LOCALE(PLUGIN_NAME, "en-US")
+
+MODULE_EXPORT const char *obs_module_name(void)
+{
+    return obs_module_text("GameCapture");
+}
+
+MODULE_EXPORT const char *obs_module_description(void)
+{
+    return obs_module_text("Description");
+}


### PR DESCRIPTION
Add optional metadata for the plugin, which can be retrieved by other plugins through the libobs `obs_enum_modules` API call.
