### PR TITLE
expose capture stats via shm

### DIFF
--- a/src/capture.h
+++ b/src/capture.h
@@ -95,6 +95,7 @@ struct capture_stats_data
     uint64_t bytes;
 };
 #define CAPTURE_STATS_SHM "/com_obsproject_vkcapture_CaptureStats"
+#define CAPTURE_STATS_SEM "/com_obsproject_vkcapture_CaptureStatsSem"
 
 void capture_init();
 void capture_update_socket();


### PR DESCRIPTION
the end intention is to allow mangohud to read capture data like file size and recording time, much like how msi afterburner does it
[it had previously been a requested feature](https://github.com/flightlessmango/MangoHud/issues/448)

# issues:
## multiple clients might reset record stats [ ❌ ]
- perhaps move the creation of shm to the plugin? but mangohud won't find it unless it's also signalled shm is ready for reading